### PR TITLE
Added the new AWS regions availables

### DIFF
--- a/Sources/AWSLambdaEvents/AWSRegion.swift
+++ b/Sources/AWSLambdaEvents/AWSRegion.swift
@@ -26,19 +26,26 @@ public struct AWSRegion: RawRepresentable, Equatable {
     }
 
     static var all: [AWSRegion] = [
+        Self.af_south_1,
         Self.ap_northeast_1,
         Self.ap_northeast_2,
         Self.ap_east_1,
         Self.ap_southeast_1,
         Self.ap_southeast_2,
+        Self.ap_southeast_3,
+        Self.ap_southeast_4,
         Self.ap_south_1,
+        Self.ap_south_2,
         Self.cn_north_1,
         Self.cn_northwest_1,
         Self.eu_north_1,
+        Self.eu_south_1,
+        Self.eu_south_2,
         Self.eu_west_1,
         Self.eu_west_2,
         Self.eu_west_3,
         Self.eu_central_1,
+        Self.eu_central_2,
         Self.us_east_1,
         Self.us_east_2,
         Self.us_west_1,
@@ -47,24 +54,33 @@ public struct AWSRegion: RawRepresentable, Equatable {
         Self.us_gov_west_1,
         Self.ca_central_1,
         Self.sa_east_1,
+        Self.me_central_1,
         Self.me_south_1,
     ]
+
+    public static var af_south_1: Self { AWSRegion(rawValue: "af-south-1")! }
 
     public static var ap_northeast_1: Self { AWSRegion(rawValue: "ap-northeast-1")! }
     public static var ap_northeast_2: Self { AWSRegion(rawValue: "ap-northeast-2")! }
     public static var ap_east_1: Self { AWSRegion(rawValue: "ap-east-1")! }
     public static var ap_southeast_1: Self { AWSRegion(rawValue: "ap-southeast-1")! }
     public static var ap_southeast_2: Self { AWSRegion(rawValue: "ap-southeast-2")! }
+    public static var ap_southeast_3: Self { AWSRegion(rawValue: "ap-southeast-3")! }
+    public static var ap_southeast_4: Self { AWSRegion(rawValue: "ap-southeast-4")! }
     public static var ap_south_1: Self { AWSRegion(rawValue: "ap-south-1")! }
+    public static var ap_south_2: Self { AWSRegion(rawValue: "ap-south-2")! }
 
     public static var cn_north_1: Self { AWSRegion(rawValue: "cn-north-1")! }
     public static var cn_northwest_1: Self { AWSRegion(rawValue: "cn-northwest-1")! }
 
     public static var eu_north_1: Self { AWSRegion(rawValue: "eu-north-1")! }
+    public static var eu_south_1: Self { AWSRegion(rawValue: "eu-south-1")! }
+    public static var eu_south_2: Self { AWSRegion(rawValue: "eu-south-2")! }
     public static var eu_west_1: Self { AWSRegion(rawValue: "eu-west-1")! }
     public static var eu_west_2: Self { AWSRegion(rawValue: "eu-west-2")! }
     public static var eu_west_3: Self { AWSRegion(rawValue: "eu-west-3")! }
     public static var eu_central_1: Self { AWSRegion(rawValue: "eu-central-1")! }
+    public static var eu_central_2: Self { AWSRegion(rawValue: "eu-central-2")! }
 
     public static var us_east_1: Self { AWSRegion(rawValue: "us-east-1")! }
     public static var us_east_2: Self { AWSRegion(rawValue: "us-east-2")! }
@@ -75,6 +91,7 @@ public struct AWSRegion: RawRepresentable, Equatable {
 
     public static var ca_central_1: Self { AWSRegion(rawValue: "ca-central-1")! }
     public static var sa_east_1: Self { AWSRegion(rawValue: "sa-east-1")! }
+    public static var me_central_1: Self { AWSRegion(rawValue: "me-central-1")! }
     public static var me_south_1: Self { AWSRegion(rawValue: "me-south-1")! }
 }
 


### PR DESCRIPTION
Added the Amazon regions created until January 2023 that are not included in the `AWSRegion` type.

* **Africa**
    * Cape City (`af-south-1`)
* **Asia Pacific**
    * Melbourne (`ap-southeast-4`)  
    * Hyderabad (`ap-south-2`)
    * Yakarta (`ap-southeast-3`)
* **Europe**
    * Milano, Italy (`eu-south-1`)
    * Madrid🤘😜, Spain  (`eu-south-2`)
    * Zurich, Switzerland (`eu-central-2`)
* **Middle East**
    * UAE(`me-central-1`)   